### PR TITLE
fix: override input padding from mdbootstrap

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -179,6 +179,11 @@ html {
   }
 }
 
+.form-control {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   color: #211E3C;


### PR DESCRIPTION
mdbootstrap explicitly sets input padding-top & bottom ignoring vars.